### PR TITLE
Fix h1 heading level in Sesotho explain-bitcoin-like-im-five

### DIFF
--- a/docs/zaf/st/explain-bitcoin-like-im-five/README.md
+++ b/docs/zaf/st/explain-bitcoin-like-im-five/README.md
@@ -13,7 +13,7 @@ supporters:
         href: "https://blog.bitmex.com/bitmex-grant-translation-of-bitcoin-content-into-african-languages/"
 ---
 
-## Hlalosa Bitcoin joalo eka ke lilemo tse hlano.
+# Hlalosa Bitcoin joalo eka ke lilemo tse hlano.
 
 e ngotsoe ke Nik Custodio  [2013/12/12](https://www.freecodecamp.org/news/explain-bitcoin-like-im-five-73b4257ac833/)
 


### PR DESCRIPTION
The title was using ## (h2) instead of # (h1), causing VuePress to not pick up the page title — the browser tab and sidebar showed the folder name instead of "Hlalosa Bitcoin joalo eka ke lilemo tse hlano."